### PR TITLE
Keep \n's for Curl template parameter

### DIFF
--- a/expensify_export.sh
+++ b/expensify_export.sh
@@ -255,7 +255,7 @@ log "debug" "export filename: $EXPORT_FILE"
 URL="https://$HOSTNAME/Integration-Server/ExpensifyIntegrations"
 JSON=$(build_json_request "requestExport")
 log "debug" "json_request: $JSON"
-TEMPLATE_DATA=$(cat "$TEMPLATE_FILE" | tr '\n' ' ')
+TEMPLATE_DATA=$(cat "$TEMPLATE_FILE")
 CURL_OPTS="--include -sL -H 'Expect:' --data-urlencode \""$JSON"\" --data-urlencode 'template=$TEMPLATE_DATA' $URL"
 CURL_CMD="curl $CURL_OPTS"
 log "debug" "curl command: $CURL_CMD"


### PR DESCRIPTION
@tonyzakula @mcnamamj 

As found with @righdforsa, the `tr` caused the server to receive the template in only one line, so all the ouput was also on one line.
Matt seemed to say that it was working fine for him before (with the `tr`), so if it's possible please try again without it and let me know if it still works.
